### PR TITLE
RFC: Add an RFC Process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenDream RFC Repo
 
-This repository stores RFCs for the [OpenDream](https://github.com/OpenDreamProject/OpenDream) project. Current and future users of OpenDream are strongly encouraged to watch this repository and provide constructive input on all open pull requests.
+This repository stores RFCs _(Request For Comments)_ for the [OpenDream](https://github.com/OpenDreamProject/OpenDream) project. Current and future users of OpenDream are strongly encouraged to watch this repository and provide constructive input on all open pull requests.
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Although the core goal of OpenDream is to provide one-way parity with BYOND, the
 A key example of this is [pragmas](https://github.com/OpenDreamProject/OpenDream/wiki/Pragmas---Error-Emissions). Pragmas provide configurable compiler emissions for things such as runtime errors that *can* be detected at compiletime but BYOND fails to detect. Utilizing pragmas while maintaining BYOND compatibility is as simple as declaring them in their own code file and putting this in your code somewhere:
 ```
 #ifdef OPENDREAM
-#include("/path/to/pragma/file.dm") // Don't include the file of pragmas unless `OPENDREAM` is defined (which OpenDream defines for you)
+// Don't include the file of pragmas unless `OPENDREAM` is defined (which OpenDream defines for you)
+#include("/path/to/pragma/file.dm")
 #endif
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Every open RFC will be open for at least two calendar weeks. This is to make sur
 
 The first week should be used to resolve any major technical or design problems raised by the OpenDream team, though everyone is encouraged to provide input. After the first week and any major problems are resolved, a member of the OpenDream team should share the RFC in the following places to solicit feedback from the wider community for the second week:
 - `#codebase-announcements` channel in OpenDream's Discord.
-- `#headcoderbus` channel in coderbus's Discord.
+- `#maintainerbus` channel in coderbus's Discord.
 - `#coderbus` channel in coderbus's Discord.
 
 When the initial comment period expires, the RFC can be merged if there's consensus that the change is important and that the details of the syntax/semantics presented are workable. The decision to merge the RFC is made by the OpenDream team.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As the OpenDream userbase grows, reversing these decisions will only become more
 To open an RFC, a Pull Request must be opened which creates a new Markdown file in `docs/` folder. The RFCs should follow the template `TEMPLATE.md`, and should have a file name that matches the RFC's title.
 
 ### RFC Drafts
-If you are in the early stages of the RFC and would like to solicit feedback on major considerations for your proposal, but it isn't ready for formal review, you can open your RFC as a Draft Pull Request. Once you are ready, mark it as ready for review and proceed to the below section:
+If you are in the early stages of designing the RFC and would like to solicit feedback on major considerations for your proposal, but it isn't ready for formal review, you can open your RFC as a Draft Pull Request. Once you are ready, mark it as ready for review and proceed to the below section:
 
 ### RFC Review & Finalization
 Every open RFC will be open for at least two calendar weeks. This is to make sure that there is sufficient time to review the proposal and raise concerns or suggest improvements. The discussion points should be reflected on the PR comments; when discussion happens outside of the comment stream, the points salient to the RFC should be summarized as a followup.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,59 @@
-# OpenDream RFC Repository
-WIP
+# OpenDream RFC Repo
+
+This repository stores RFCs for the [OpenDream](https://github.com/OpenDreamProject/OpenDream) project. Current and future users of OpenDream are strongly encouraged to watch this repository and provide constructive input on all open pull requests.
+
+## Motivation
+
+Although the core goal of OpenDream is to provide one-way parity with BYOND, there are [many opportunities](https://github.com/OpenDreamProject/OpenDream/wiki/Differences-Between-OpenDream-and-BYOND#enhancements) in which OpenDream and the DM language can be improved while still enabling users to migrate from BYOND with minimal effort. Or to put it another way, we can add new functionality *on top* of BYOND parity so that OpenDream users can take advantage of them while BYOND users are not impacted. 
+
+A key example of this is [pragmas](https://github.com/OpenDreamProject/OpenDream/wiki/Pragmas---Error-Emissions). Pragmas provide configurable compiler emissions for things such as runtime errors that *can* be detected at compiletime but BYOND fails to detect. Utilizing pragmas while maintaining BYOND compatibility is as simple as declaring them in their own code file and putting this in your code somewhere:
+```
+#ifdef OPENDREAM
+#include("/path/to/pragma/file.dm") // Don't include the file of pragmas unless `OPENDREAM` is defined (which OpenDream defines for you)
+#endif
+```
+
+Furthermore, OpenDream is intended to provide a solution for *everyone* and not any specific codebase. To prevent any one person from turning the project into their own new programming language, this RFC process exists to solicit input from the wider community on any major changes that would impact their current or future usage of OpenDream.
+
+## RFC Considerations
+
+Whenever new syntax is introduced, we need to ask:
+
+- Is it BYOND compatible?
+- Is it easy for machines and humans to parse?
+- Does it create grammar ambiguities for current and future syntax?
+- Is it stylistically coherent with the rest of the language?
+- Does it present challenges with editor integration like autocomplete?
+
+For changes in semantics, we should be asking:
+
+- Is behavior easy to understand and non-surprising?
+- Can it be implemented performantly today?
+- Is it compatible with type checking and other forms of static analysis?
+
+As the OpenDream userbase grows, reversing these decisions will only become more costly and have backwards compatibility implications.
+
+## RFC Process
+
+To open an RFC, a Pull Request must be opened which creates a new Markdown file in `docs/` folder. The RFCs should follow the template `TEMPLATE.md`, and should have a file name that matches the RFC's title.
+
+### RFC Drafts
+If you are in the early stages of the RFC and would like to solicit feedback on major considerations for your proposal, but it isn't ready for formal review, you can open your RFC as a Draft Pull Request. Once you are ready, mark it as ready for review and proceed to the below section:
+
+### RFC Review & Finalization
+Every open RFC will be open for at least two calendar weeks. This is to make sure that there is sufficient time to review the proposal and raise concerns or suggest improvements. The discussion points should be reflected on the PR comments; when discussion happens outside of the comment stream, the points salient to the RFC should be summarized as a followup.
+
+The first week should be used to resolve any major technical or design problems raised by the OpenDream team, though everyone is encouraged to provide input. After the first week and any major problems are resolved, a member of the OpenDream team should share the RFC in the following places to solicit feedback from the wider community for the second week:
+- `#codebase-announcements` channel in OpenDream's Discord.
+- `#headcoderbus` channel in coderbus's Discord.
+- `#coderbus` channel in coderbus's Discord.
+
+When the initial comment period expires, the RFC can be merged if there's consensus that the change is important and that the details of the syntax/semantics presented are workable. The decision to merge the RFC is made by the OpenDream team.
+
+If at any point the RFC undergoes substantial changes (anything more than spelling/formatting/wording), the two-week timer should be reset to the time the last substantial commit was pushed.
+
+In general, RFCs can also be updated after merging to make the language of the RFC more clear, but should not change their meaning. When a new feature is built on top of an existing feature that has an RFC, a new RFC should be created instead of editing an existing RFC. That being said, a superceded RFC should be edited to include a notice and a link to the new RFC.
+
+When there's no consensus that the feature is broadly beneficial and can be implemented, an RFC will be closed. The decision to close the RFC is made by the OpenDream team.
+
+Note that in some cases an RFC may be closed because we don't have sufficient data or believe that at this point in time, the stars do not line up sufficiently for this change to be worthwhile, but this doesn't mean that it may never be considered again; an RFC PR may be reopened if new data is available since the original discussion, or if the PR has changed substantially to address the core problems raised in the prior round.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ If you are in the early stages of designing the RFC and would like to solicit fe
 Every open RFC will be open for at least two calendar weeks. This is to make sure that there is sufficient time to review the proposal and raise concerns or suggest improvements. The discussion points should be reflected on the PR comments; when discussion happens outside of the comment stream, the points salient to the RFC should be summarized as a followup.
 
 The first week should be used to resolve any major technical or design problems raised by the OpenDream team, though everyone is encouraged to provide input. After the first week and any major problems are resolved, a Maintainer from the OpenDream team should share the RFC in the following places to solicit feedback from the wider community for the second week:
-- `#codebase-announcements` channel in OpenDream's Discord.
-- `#maintainerbus` channel in coderbus's Discord.
-- `#coderbus` channel in coderbus's Discord.
+- `#codebase-announcements` channel in OpenDream's [Discord](https://discord.gg/UScStz6hnQ).
+- `#maintainerbus` channel in coderbus's [Discord](https://discord.gg/Vh8TJp9).
+- `#coderbus` channel in coderbus's [Discord](https://discord.gg/Vh8TJp9).
 
 When the initial comment period expires, the RFC can be merged if there's consensus that the change is important and that the details of the syntax/semantics presented are workable. The decision to merge the RFC is made by the OpenDream team.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you are in the early stages of designing the RFC and would like to solicit fe
 ### RFC Review & Finalization
 Every open RFC will be open for at least two calendar weeks. This is to make sure that there is sufficient time to review the proposal and raise concerns or suggest improvements. The discussion points should be reflected on the PR comments; when discussion happens outside of the comment stream, the points salient to the RFC should be summarized as a followup.
 
-The first week should be used to resolve any major technical or design problems raised by the OpenDream team, though everyone is encouraged to provide input. After the first week and any major problems are resolved, a member of the OpenDream team should share the RFC in the following places to solicit feedback from the wider community for the second week:
+The first week should be used to resolve any major technical or design problems raised by the OpenDream team, though everyone is encouraged to provide input. After the first week and any major problems are resolved, a Maintainer from the OpenDream team should share the RFC in the following places to solicit feedback from the wider community for the second week:
 - `#codebase-announcements` channel in OpenDream's Discord.
 - `#maintainerbus` channel in coderbus's Discord.
 - `#coderbus` channel in coderbus's Discord.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The first week should be used to resolve any major technical or design problems 
 
 When the initial comment period expires, the RFC can be merged if there's consensus that the change is important and that the details of the syntax/semantics presented are workable. The decision to merge the RFC is made by the OpenDream team.
 
-If at any point the RFC undergoes substantial changes (anything more than spelling/formatting/wording), the two-week timer may (at OpenDream staff discretion) be reset to the time the last substantial commit was pushed.
+If at any point the RFC undergoes substantial changes (anything more than spelling/formatting/wording), the two-week timer may (at OpenDream Maintainer discretion) be reset to the time the last substantial commit was pushed.
 
 In general, RFCs can also be updated after merging to make the language of the RFC more clear, but should not change their meaning. When a new feature is built on top of an existing feature that has an RFC, a new RFC should be created instead of editing an existing RFC. That being said, a superceded RFC should be edited to include a notice and a link to the new RFC.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The first week should be used to resolve any major technical or design problems 
 
 When the initial comment period expires, the RFC can be merged if there's consensus that the change is important and that the details of the syntax/semantics presented are workable. The decision to merge the RFC is made by the OpenDream team.
 
-If at any point the RFC undergoes substantial changes (anything more than spelling/formatting/wording), the two-week timer should be reset to the time the last substantial commit was pushed.
+If at any point the RFC undergoes substantial changes (anything more than spelling/formatting/wording), the two-week timer may (at OpenDream staff discretion) be reset to the time the last substantial commit was pushed.
 
 In general, RFCs can also be updated after merging to make the language of the RFC more clear, but should not change their meaning. When a new feature is built on top of an existing feature that has an RFC, a new RFC should be created instead of editing an existing RFC. That being said, a superceded RFC should be edited to include a notice and a link to the new RFC.
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,0 +1,43 @@
+# Short, Properly Capitalized Title of RFC
+
+<!-->Your title should convey the basic jist of your proposed changes. It should be short.<!-->
+
+<!-->Avoid modifying the first two rows of the table<!-->
+| Lead Author(s) | Implemented | GitHub Links |
+|---|---|---|
+<!-->Fill in this bottom row:<!-->| Your Name(s) Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Link(s) or TBD |
+
+<!-->
+`Lead Authors` should be the names that you use on GitHub and/or Discord. This is optional but strongly recommended, since:
+
+- This acknowledges credit where it is due
+- People who are confused about the written intent can use this information to contact the authors
+
+`Implemented` is the status of the feature. The PR implementing this RFC should go back and edit this RFC accordingly and include a link to the PR.
+
+Github links can include multiple PRs, if relevant. If it has not been implemented at all, leave as "TBD" (to be determined).
+!-->
+
+<!--> For each subsection below, replace the explanatory text with your proposal <!-->
+
+## Overview
+
+A short, roughly one paragraph summary of what this proposal is about. A high level "overview" or "what this does".
+
+## Motivation
+
+Why are we doing this? What use cases does it support? What is the expected outcome?
+
+## Design
+
+This is the bulk of the proposal. Explain the design in enough detail for somebody familiar with the language to understand, and include examples of how the feature is used. Also describe how codebases operating on BYOND can still utilize or ignore the feature as they see fit.
+
+## Considerations & Drawbacks
+
+What are some aspects we should consider? Why should we *not* do this?
+
+Focal points should include (but are not limited to):
+- Performance
+- BYOND parity
+- Impact on users migrating to OpenDream
+- Impact on *all* major SS13 forks and potentially other BYOND games, not just the author's codebase

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -1,14 +1,11 @@
 # Short, Properly Capitalized Title of RFC
 
-<!-->Your title should convey the basic jist of your proposed changes. It should be short.<!-->
+Your title should convey the basic jist of your proposed changes. It should be short. Also, make sure you fill in the table below and remove these explanatory sentences.
 
-<!-->Avoid modifying the first two rows of the table<!-->
-<!-->Fill in the bottom row<!-->
 | Lead Author(s) | Implemented | GitHub Links |
 |---|---|---|
 | Your Name(s) Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Link(s) or TBD |
 
-<!-->
 `Lead Authors` should be the names that you use on GitHub and/or Discord. This is optional but strongly recommended, since:
 
 - This acknowledges credit where it is due
@@ -17,9 +14,8 @@
 `Implemented` is the status of the feature. The PR implementing this RFC should go back and edit this RFC accordingly and include a link to the PR.
 
 Github links can include multiple PRs, if relevant. If it has not been implemented at all, leave as "TBD" (to be determined).
-!-->
 
-<!--> For each subsection below, replace the explanatory text with your proposal <!-->
+For each subsection below, replace the explanatory text with your proposal.
 
 ## Overview
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -3,9 +3,10 @@
 <!-->Your title should convey the basic jist of your proposed changes. It should be short.<!-->
 
 <!-->Avoid modifying the first two rows of the table<!-->
+<!-->Fill in the bottom row<!-->
 | Lead Author(s) | Implemented | GitHub Links |
 |---|---|---|
-<!-->Fill in this bottom row:<!-->| Your Name(s) Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Link(s) or TBD |
+| Your Name(s) Here | :white_check_mark: Yes or :warning: Partially or :information_source: Open PR or :x: No | PR Link(s) or TBD |
 
 <!-->
 `Lead Authors` should be the names that you use on GitHub and/or Discord. This is optional but strongly recommended, since:


### PR DESCRIPTION
Read the files if you want a description. The first RFC is the RFC process, but since it's the README it's not going in the  `docs` folder that will house all future RFCs.

This RFC pulls heavy inspiration from https://github.com/luau-lang/rfcs and https://github.com/space-wizards/docs/blob/master/src/en/templates/proposal.md with my own changes as well.